### PR TITLE
Exclude some VSCode extension temp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ TestResults.xml
 rad.json
 .output
 cache_*
+.alcache/
+.altemplates/


### PR DESCRIPTION
Updated template .gitignore file to exclude temp directories used by some VSCode extensions. 
This avoids customisation of .gitignore on per-project basis.

---

Covers task 2. from https://github.com/microsoft/AL-Go/issues/62

When working with 3rd party extensions, some extensions add extra folders / files that should not be tracked either. What would be the recommendation for those? Contribute to the .gitignore on this repo and manage a common config (instead of creating a custom template)?

```
.alcache/
.altemplates/
```