### PR TITLE
settings.json to include bcptTestFolders

### DIFF
--- a/.AL-Go/settings.json
+++ b/.AL-Go/settings.json
@@ -3,5 +3,7 @@
     "appFolders":  [
     ],
     "testFolders":  [
+    ],
+    "bcptTestFolders":  [
     ]
 }


### PR DESCRIPTION
bcptTestFolders must exist in settings.json before "Create a new performance test app" workflow will run.