### PR TITLE
Added LFS support for checkout

### DIFF
--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -33,8 +33,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          lfs: true
 
       - name: Initialize the workflow
         id: init
@@ -86,6 +84,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          lfs: true
 
       - name: Read settings
         uses: microsoft/AL-Go-Actions/ReadSettings@v1.5

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          lfs: true
 
       - name: Initialize the workflow
         id: init


### PR DESCRIPTION
To be able to store dependencies (to be specified in installApps) using GIT LFS we need to ensure that the CI flow actually enables the LFS during checkout.